### PR TITLE
Validate cloud event shell

### DIFF
--- a/lib/core/event.ex
+++ b/lib/core/event.ex
@@ -14,9 +14,9 @@ defmodule Polyn.Event do
             source: nil,
             time: nil,
             polyntrace: [],
-            polynclient: %{
-              lang: "elixir",
-              langversion: System.build_info().version
+            polyndata: %{
+              clientlang: "elixir",
+              clientlangversion: System.build_info().version
             }
 
   @type polyntrace :: %{
@@ -35,7 +35,7 @@ defmodule Polyn.Event do
   `source` - Identifies the context in which an event happened.
   `time` - Timestamp of when the occurrence happened. Must adhere to RFC 3339.
   `polyntrace` - Previous events that led to this one
-  `polynclient` - Information about the client that produced the event
+  `polyndata` - Information about the client that produced the event and additional data
   """
   @type t() :: %__MODULE__{
           id: String.t(),
@@ -47,7 +47,7 @@ defmodule Polyn.Event do
           source: String.t(),
           time: String.t(),
           polyntrace: list(polyntrace()),
-          polynclient: map()
+          polyndata: map()
         }
 
   @doc """
@@ -84,7 +84,7 @@ defmodule Polyn.Event do
   end
 
   defp add_polyn_version(%__MODULE__{} = event) do
-    put_in(event, [Access.key!(:polynclient), :version], polyn_version())
+    put_in(event, [Access.key!(:polyndata), :clientversion], polyn_version())
   end
 
   defp polyn_version do

--- a/priv/polyn/cloud_event_schema.json
+++ b/priv/polyn/cloud_event_schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "CloudEvents Specification JSON Schema",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Identifies the event.",
+      "$ref": "#/definitions/iddef",
+      "examples": [
+        "A234-1234-1234"
+      ]
+    },
+    "source": {
+      "description": "Identifies the context in which an event happened.",
+      "$ref": "#/definitions/sourcedef",
+      "examples" : [
+        "https://github.com/cloudevents",
+        "mailto:cncf-wg-serverless@lists.cncf.io",
+        "urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66",
+        "cloudevents/spec/pull/123",
+        "/sensors/tn-1234567/alerts",
+        "1-555-123-4567"
+      ]
+    },
+    "specversion": {
+      "description": "The version of the CloudEvents specification which the event uses.",
+      "$ref": "#/definitions/specversiondef",
+      "examples": [
+        "1.0"
+      ]
+    },
+    "type": {
+      "description": "Describes the type of event related to the originating occurrence.",
+      "$ref": "#/definitions/typedef",
+      "examples" : [
+        "com.github.pull_request.opened",
+        "com.example.object.deleted.v2"
+      ]
+    },
+    "datacontenttype": {
+      "description": "Content type of the data value. Must adhere to RFC 2046 format.",
+      "$ref": "#/definitions/datacontenttypedef",
+      "examples": [
+        "text/xml",
+        "application/json",
+        "image/png",
+        "multipart/form-data"
+      ]
+    },
+    "dataschema": {
+      "description": "Identifies the schema that data adheres to.",
+      "$ref": "#/definitions/dataschemadef"
+    },
+    "subject": {
+      "description": "Describes the subject of the event in the context of the event producer (identified by source).",
+      "$ref": "#/definitions/subjectdef",
+      "examples": [
+        "mynewfile.jpg"
+      ]
+    },
+    "time": {
+      "description": "Timestamp of when the occurrence happened. Must adhere to RFC 3339.",
+      "$ref": "#/definitions/timedef",
+      "examples": [
+        "2018-04-05T17:31:00Z"
+      ]
+    },
+    "data": {
+      "description": "The event payload.",
+      "$ref": "#/definitions/datadef",
+      "examples": [
+        "<much wow=\"xml\"/>"
+      ]
+    },
+    "data_base64": {
+      "description": "Base64 encoded event payload. Must adhere to RFC4648.",
+      "$ref": "#/definitions/data_base64def",
+      "examples": [
+        "Zm9vYg=="
+      ]
+    },
+    "polyndata": {
+      "$ref": "#/definitions/polyndatadef",
+      "description": "Information about the client that produced the event and additional metadata",
+      "examples": [
+        {
+          "clientlang": "elixir",
+          "clientlangversion": "1.13.2",
+          "clientversion": "0.1.0"
+        }
+      ]
+    },
+    "polyntrace": {
+      "$ref": "#/definitions/polyntracedef",
+      "description": "Previous events that led to this one",
+      "examples": [
+        [
+          {
+            "type": "<topic>",
+            "time": "2018-04-05T17:31:00Z",
+            "id": "<uuid>"
+          }
+        ]
+      ]
+    }
+  },
+  "required": ["id", "source", "specversion", "type"],
+  "definitions": {
+    "iddef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourcedef": {
+      "type": "string",
+      "format": "uri-reference",
+      "minLength": 1
+    },
+    "specversiondef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "typedef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "datacontenttypedef": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "dataschemadef": {
+      "type": ["string", "null"],
+      "format": "uri",
+      "minLength": 1
+    },
+    "subjectdef": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "timedef": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "minLength": 1
+    },
+    "datadef": {
+      "type": ["object", "string", "number", "array", "boolean", "null"]
+    },
+    "data_base64def": {
+      "type": ["string", "null"],
+      "contentEncoding": "base64"
+    },
+    "polyndatadef": {
+      "type": "object",
+      "properties": {
+        "clientlang": {
+          "type": "string"
+        },
+        "clientlangversion": {
+          "type": "string"
+        },
+        "clientversion": {
+          "type": "string"
+        }
+      },
+      "required": ["clientlang", "clientlangversion", "clientversion"]
+    },
+    "polyntracedef": {
+      "type" : "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "time": {
+            "type": "date-time"
+          },
+          "id"  : {
+            "type": "uuid"
+          }
+        },
+        "required": ["type", "time", "id"]
+      }
+    }
+  }
+}

--- a/priv/polyn/cloud_event_schema.json
+++ b/priv/polyn/cloud_event_schema.json
@@ -172,10 +172,12 @@
             "type": "string"
           },
           "time": {
-            "type": "date-time"
+            "type": "string",
+            "format": "date-time"
           },
           "id"  : {
-            "type": "uuid"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": ["type", "time", "id"]

--- a/test/core/event_test.exs
+++ b/test/core/event_test.exs
@@ -19,7 +19,7 @@ defmodule Polyn.EventTest do
   end
 
   test "new/1 adds polyn_version" do
-    assert %Event{polynclient: %{version: version}} = Event.new([])
+    assert %Event{polyndata: %{clientversion: version}} = Event.new([])
     assert version == "#{Application.spec(:polyn, :vsn)}"
   end
 

--- a/test/core/json_serializer_test.exs
+++ b/test/core/json_serializer_test.exs
@@ -175,10 +175,10 @@ defmodule Polyn.Serializers.JSONTest do
                "source" => "test",
                "time" => ^now,
                "polyntrace" => [],
-               "polynclient" => %{
-                 "lang" => "elixir",
-                 "langversion" => ^langversion,
-                 "version" => ^version
+               "polyndata" => %{
+                 "clientlang" => "elixir",
+                 "clientlangversion" => ^langversion,
+                 "clientversion" => ^version
                },
                "data" => nil,
                "datacontenttype" => "application/json"

--- a/test/core/json_serializer_test.exs
+++ b/test/core/json_serializer_test.exs
@@ -122,6 +122,13 @@ defmodule Polyn.Serializers.JSONTest do
       assert message =~ "Property: `#/data/foo` - Type mismatch. Expected Integer but got String."
     end
 
+    test "error if data isn't cloudevent" do
+      {:error, message} = JSON.deserialize("123", @conn_name, store_name: @store_name)
+
+      assert message =~ "Polyn events need to follow the CloudEvent spec"
+      assert message =~ "Expected Object but got Integer"
+    end
+
     test "error if payload is not decodeable" do
       assert {:error, message} = JSON.deserialize("foo", @conn_name, store_name: @store_name)
 

--- a/test/core/pull_consumer_test.exs
+++ b/test/core/pull_consumer_test.exs
@@ -65,6 +65,10 @@ defmodule Polyn.PullConsumerTest do
   test "receives a message" do
     Gnat.pub(@conn_name, "user.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.user.created.v1",
+      "specversion": "1.0.1",
       "type": "com.test.user.created.v1",
       "data": {
         "name": "Toph",
@@ -75,6 +79,10 @@ defmodule Polyn.PullConsumerTest do
 
     Gnat.pub(@conn_name, "user.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.user.created.v1",
+      "specversion": "1.0.1",
       "type": "com.test.user.created.v1",
       "data": {
         "name": "Katara",
@@ -112,6 +120,10 @@ defmodule Polyn.PullConsumerTest do
   test "errors if payload is invalid" do
     Gnat.pub(@conn_name, "user.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.user.created.v1",
+      "specversion": "1.0.1",
       "type": "com.test.user.created.v1",
       "data": {
         "name": 123,
@@ -130,6 +142,10 @@ defmodule Polyn.PullConsumerTest do
   test "receives next message after error" do
     Gnat.pub(@conn_name, "user.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.user.created.v1",
+      "specversion": "1.0.1",
       "type": "com.test.user.created.v1",
       "data": {
         "name": 123,
@@ -140,6 +156,10 @@ defmodule Polyn.PullConsumerTest do
 
     Gnat.pub(@conn_name, "user.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.user.created.v1",
+      "specversion": "1.0.1",
       "type": "com.test.user.created.v1",
       "data": {
         "name": "Toph",

--- a/test/core/subscriber_test.exs
+++ b/test/core/subscriber_test.exs
@@ -70,9 +70,18 @@ defmodule Polyn.SubscriberTest do
     pid = start_supervised!({ExampleSubscriber, %{test_pid: self()}})
     ref = Process.monitor(pid)
 
-    Polyn.pub(@conn_name, "subscriber.test.event.v1", %{name: 123, element: 456},
-      store_name: @store_name
-    )
+    Gnat.pub(@conn_name, "subscriber.test.event.v1", """
+    {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.subscriber.test.event.v1",
+      "specversion": "1.0.1",
+      "data": {
+        "name": 123,
+        "element": 456
+      }
+    }
+    """)
 
     assert_receive({:DOWN, ^ref, :process, ^pid, {%Polyn.ValidationException{}, _stack}})
   end

--- a/test/off_broadway/producer_test.exs
+++ b/test/off_broadway/producer_test.exs
@@ -72,6 +72,10 @@ defmodule OffBroadway.Polyn.ProducerTest do
   test "valid messages are converted to Event structs" do
     Gnat.pub(@conn_name, "company.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.company.created.v1",
+      "specversion": "1.0.1",
       "type": "com.test.company.created.v1",
       "data": {
         "name": "Toph",
@@ -82,6 +86,10 @@ defmodule OffBroadway.Polyn.ProducerTest do
 
     Gnat.pub(@conn_name, "company.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
+      "type": "com.test.company.created.v1",
+      "specversion": "1.0.1",
       "type": "com.test.company.created.v1",
       "data": {
         "name": "Katara",
@@ -126,6 +134,7 @@ defmodule OffBroadway.Polyn.ProducerTest do
       "id": "abc",
       "source": "com.test.foo",
       "type": "com.test.company.created.v1",
+      "specversion": "1.0.1",
       "data": {
         "name": 123,
         "element": true
@@ -135,7 +144,10 @@ defmodule OffBroadway.Polyn.ProducerTest do
 
     Gnat.pub(@conn_name, "company.created.v1", """
     {
+      "id": "abc",
+      "source": "com.test.foo",
       "type": "com.test.company.created.v1",
+      "specversion": "1.0.1",
       "data": {
         "name": "Toph",
         "element": "earth"


### PR DESCRIPTION
Validates messages against the Cloud Event schema in case a message comes in that's not registered as a polyn schema or is published without using polyn.