### PR TITLE
Fix bug where subscriber state was overwritten

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Polyn.MixProject do
 
   @github "https://github.com/SpiffInc/polyn-elixir"
 
-  def version, do: "0.1.0"
+  def version, do: "0.1.1"
 
   def project do
     [

--- a/test/core/subscriber_test.exs
+++ b/test/core/subscriber_test.exs
@@ -63,6 +63,16 @@ defmodule Polyn.SubscriberTest do
       {:received_event, %Event{data: %{"name" => "Iroh", "element" => "fire"}},
        %{reply_to: "foo"}}
     )
+
+    Polyn.pub(@conn_name, "subscriber.test.event.v1", %{name: "Toph", element: "earth"},
+      reply_to: "foo",
+      store_name: @store_name
+    )
+
+    assert_receive(
+      {:received_event, %Event{data: %{"name" => "Toph", "element" => "earth"}},
+       %{reply_to: "foo"}}
+    )
   end
 
   @tag capture_log: true


### PR DESCRIPTION
Made a mistake of directly using the implementing module's `handle_message` response for the Subscriber's return value thus overriding all the internal state