### PR TITLE
Fix bug where source name could be invalid uri

### DIFF
--- a/lib/core/event.ex
+++ b/lib/core/event.ex
@@ -107,7 +107,7 @@ defmodule Polyn.Event do
   def full_source(source) do
     case Naming.validate_source_name(source) do
       :ok ->
-        full_source() <> ":" <> source
+        full_source() <> ":" <> Naming.dot_to_colon(source)
 
       {:error, reason} ->
         raise Polyn.ValidationException, reason

--- a/test/core/event_test.exs
+++ b/test/core/event_test.exs
@@ -45,6 +45,10 @@ defmodule Polyn.EventTest do
     assert "com:test:user:backend:orders" == Event.full_source("orders")
   end
 
+  test "full_source/1 replaces dots" do
+    assert "com:test:user:backend:orders:new" == Event.full_source("orders.new")
+  end
+
   test "full_source/1 uses root if nil" do
     assert "com:test:user:backend" == Event.full_source(nil)
   end


### PR DESCRIPTION
Forgot to replace dots with colons to create a valid URI on `source` info appended to the source_root