### PR TITLE
Fix duplicate source root bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ polyn-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Elixir language server
+/.elixir_ls/

--- a/lib/core/event.ex
+++ b/lib/core/event.ex
@@ -106,7 +106,12 @@ defmodule Polyn.Event do
 
   def full_source(source) do
     Naming.validate_source_name!(source)
-    full_source() <> ":" <> Naming.dot_to_colon(source)
+    source = String.replace(source, ~r/#{full_source()}{1}:?/, "")
+
+    case source do
+      "" -> full_source()
+      name -> "#{full_source()}:#{Naming.dot_to_colon(name)}"
+    end
   end
 
   def full_source do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Polyn.MixProject do
 
   @github "https://github.com/SpiffInc/polyn-elixir"
 
-  def version, do: "0.1.3"
+  def version, do: "0.1.4"
 
   def project do
     [


### PR DESCRIPTION
If you passed in a full `source` attribute like `com:spiff:user:backend` when creating an `%Event{}` it would get duplicated to be `com:spiff:user:backend:com:spiff:user:backend`. This would happen most often when deserializing an event from JSON into an `%Event{}`. This PR attempts to fix that bug